### PR TITLE
add animations

### DIFF
--- a/components/metric.js
+++ b/components/metric.js
@@ -41,7 +41,8 @@ const Metric = ({ metric, tag }) => {
 
   const mobile = <Box>
       <Box onClick={toggle} sx={{
-      cursor: 'pointer',
+      cursor: hasDetails ? 'pointer' : 'default',
+      pointerEvents: hasDetails ? 'all' : 'none',
       '&:hover > #grid > #container > #expander': {
         fill: 'primary',
         stroke: 'primary'
@@ -91,10 +92,10 @@ const Metric = ({ metric, tag }) => {
       </Box>
       <Box sx={{
         opacity: expanded ? 1 : 0,
-        maxHeight: expanded ? '300px' : '0px',
+        maxHeight: expanded ? '400px' : '0px',
         overflow: 'hidden',
         transition: [
-          'max-height 0.15s ease-in'
+          'max-height 0.2s ease-in'
         ]
       }}>
       {expanded && 
@@ -155,7 +156,8 @@ const Metric = ({ metric, tag }) => {
     </Box>
     <Box sx={{ display: ['none', 'none', 'inherit'] }}>
     <Box onClick={toggle} sx={{
-      cursor: 'pointer',
+      cursor: hasDetails ? 'pointer' : 'default',
+      pointerEvents: hasDetails ? 'all' : 'none',
       '&:hover > #grid > #container > #expander': {
         fill: 'primary',
         stroke: 'primary'
@@ -200,7 +202,7 @@ const Metric = ({ metric, tag }) => {
     </Box>
     <Box sx={{
       opacity: expanded ? 1 : 0,
-      maxHeight: expanded ? '300px' : '0px',
+      maxHeight: expanded ? '400px' : '0px',
       overflow: 'hidden',
       transition: [
         'max-height 0.15s ease-in'

--- a/components/metric.js
+++ b/components/metric.js
@@ -39,6 +39,13 @@ const Metric = ({ metric, tag }) => {
     else return value
   }
 
+  const parseMetric = (metric) => {
+    if (metric.name != 'mechanism') return format(metric.name, metric.value)
+    if ((metric.name == 'mechanism') & (metric.removal & !metric.avoided)) return 'CDR'
+    if ((metric.name == 'mechanism') & (!metric.removal & metric.avoided)) return 'AVD'
+    if ((metric.name == 'mechanism') & (metric.removal & metric.avoided)) return 'BOTH'
+  }
+
   const mobile = <Box>
       <Box onClick={toggle} sx={{
       cursor: hasDetails ? 'pointer' : 'default',
@@ -143,13 +150,6 @@ const Metric = ({ metric, tag }) => {
       <Divider sx={{ mr: [0, 0, 2], mt: [0], mb: [0] }}/>
     </Box>
 
-  const parseMetric = (metric) => {
-    if (metric.name != 'mechanism') return format(metric.name, metric.value)
-    if ((metric.name == 'mechanism') & (metric.removal & !metric.avoided)) return 'CDR'
-    if ((metric.name == 'mechanism') & (!metric.removal & metric.avoided)) return 'AVD'
-    if ((metric.name == 'mechanism') & (metric.removal & metric.avoided)) return 'BOTH'
-  }
-
   return <Box>
     <Box sx={{ display: ['inherit', 'inherit', 'none'] }}>
       { mobile }
@@ -205,7 +205,7 @@ const Metric = ({ metric, tag }) => {
       maxHeight: expanded ? '400px' : '0px',
       overflow: 'hidden',
       transition: [
-        'max-height 0.15s ease-in'
+        'max-height 0.1s ease-in'
       ]
     }}>
     {expanded && 

--- a/components/metric.js
+++ b/components/metric.js
@@ -39,8 +39,7 @@ const Metric = ({ metric, tag }) => {
     else return value
   }
 
-  const Mobile = () => {
-    return <Box>
+  const mobile = <Box>
       <Box onClick={toggle} sx={{
       cursor: 'pointer',
       '&:hover > #grid > #container > #expander': {
@@ -48,7 +47,7 @@ const Metric = ({ metric, tag }) => {
         stroke: 'primary'
       },
       pt: [2],
-      pb: [!expanded ? 3 : 0]
+      pb: [3]
     }}>
       <Grid id='grid' columns={['1fr 30px']}>
       <Text>
@@ -90,9 +89,18 @@ const Metric = ({ metric, tag }) => {
         }
       </Box>
       </Box>
+      <Box sx={{
+        opacity: expanded ? 1 : 0,
+        maxHeight: expanded ? '300px' : '0px',
+        overflow: 'hidden',
+        transition: [
+          'max-height 0.15s ease-in'
+        ]
+      }}>
       {expanded && 
+        <Box sx={{ pb: [1] }}>
         <Box sx={{ 
-          mt: ((metric.notes || metric.comment) ? [3] : [0] ),
+          mt: ((metric.notes || metric.comment) ? [0] : [0] ),
           mb: ((metric.notes || metric.comment) ? [3] : [0] )
         }}>
         {(metric.notes) && 
@@ -102,7 +110,7 @@ const Metric = ({ metric, tag }) => {
             textAlign: ['left', 'left', 'right'], 
             mr: [2],
             ml: [0],
-            mt: [3]
+            mt: [0]
           }}>NOTES</Text>
           <Text variant='metric.comment' sx={{ 
             ml: [0]
@@ -110,7 +118,7 @@ const Metric = ({ metric, tag }) => {
           </>
         }
         <Box sx={{ 
-          mt: ((metric.notes && metric.comment) ? [2] : [0] )
+          mt: ((metric.notes && metric.comment) ? [3] : [0] )
         }}>
         </Box>
         {(metric.comment) && 
@@ -120,7 +128,7 @@ const Metric = ({ metric, tag }) => {
             textAlign: ['left'], 
             mr: [2],
             ml: [0],
-            mt: [3]
+            mt: [0]
           }}>COMMENT</Text>
           <Text variant='metric.comment' sx={{ 
             ml: [0]
@@ -128,10 +136,11 @@ const Metric = ({ metric, tag }) => {
           </>
         }
         </Box>
+        </Box>
       }
+      </Box>
       <Divider sx={{ mr: [0, 0, 2], mt: [0], mb: [0] }}/>
     </Box>
-  }
 
   const parseMetric = (metric) => {
     if (metric.name != 'mechanism') return format(metric.name, metric.value)
@@ -142,7 +151,7 @@ const Metric = ({ metric, tag }) => {
 
   return <Box>
     <Box sx={{ display: ['inherit', 'inherit', 'none'] }}>
-      <Mobile/>
+      { mobile }
     </Box>
     <Box sx={{ display: ['none', 'none', 'inherit'] }}>
     <Box onClick={toggle} sx={{
@@ -152,7 +161,7 @@ const Metric = ({ metric, tag }) => {
         stroke: 'primary'
       },
       pt: [2],
-      pb: [!expanded ? 2 : 0]
+      pb: [2]
     }}>
       <Grid id='grid' gap={['16px']} columns={
         ['85px 100px 1fr 110px 30px']
@@ -189,10 +198,19 @@ const Metric = ({ metric, tag }) => {
         }
       </Grid>
     </Box>
+    <Box sx={{
+      opacity: expanded ? 1 : 0,
+      maxHeight: expanded ? '300px' : '0px',
+      overflow: 'hidden',
+      transition: [
+        'max-height 0.15s ease-in'
+      ]
+    }}>
     {expanded && 
+      <Box sx={{ pb: [1] }}>
       <Box sx={{ 
         mt: ((metric.notes || metric.comment) ? [2] : [0] ),
-        mb: ((metric.notes || metric.comment) ? [3] : [0] )
+        mb: ((metric.notes || metric.comment) ? [2] : [0] )
       }}>
       {(metric.notes) && 
         <Grid 
@@ -235,7 +253,9 @@ const Metric = ({ metric, tag }) => {
         </Grid>
       }
       </Box>
+      </Box>
     }
+    </Box>
     <Divider sx={{ mr: [2], mt: [0], mb: [0] }}/>
     </Box>
   </Box>

--- a/components/report.js
+++ b/components/report.js
@@ -91,45 +91,54 @@ const Report = ({ project }) => {
       </Grid>
       </Box>
       <Box sx={{
-        pr: [0, 0, 4]
+        pr: [0, 0, 4],
+        opacity: (expanded || showOne) ? 1 : 0,
+        maxHeight: (expanded || showOne) ? '800px' : '0px',
+        overflow: 'hidden',
+        transition: [
+          'opacity 0.15s ease-in, max-height 0.25s ease-in',
+          'opacity 0.15s ease-in, max-height 0.25s ease-in',
+          'max-height 0.15s ease-in'
+        ]
       }}>
         {(expanded || showOne) && 
-          <Box sx={{ pb: [2, 2, '18px'] }}>
-          <Divider sx={{ mr: [0, 0, 2], mt: [0], mb: [0] }}/>
-          {metrics.map((metric) => 
-            <Metric 
-              key={metric.name} 
-              tag={project.tags[0]}
-              metric={metric}
-            ></Metric>) }
-          <Grid columns={[1, 1, '300px 1fr']}>
-            <Box sx={{ fontSize: [1], mt: ['8px', '8px', 2] }}>
-              <Text sx={{ color: 'secondary' }}>Source</Text>
-              <Text>
-                <Link sx={{ 
-                  textDecoration: 'none',
-                  '&:hover': {
-                    color: 'secondary'
-                  },
-                  '&:hover > #arrow': {
-                    color: 'secondary'
-                  }
-                }} href={ project.source.url }>
-                  { project.source.name }
-                  <Text id='arrow' variant='arrow'>↗</Text>
-                </Link>
-              </Text>
-            </Box>
-            <Box sx={{ fontSize: [1], pr: [2], mt: [0, 0, 2], mb: [2, 2, 0], textAlign: ['left', 'left', 'right'] }}>
-              <Text sx={{ color: 'secondary' }}>Location</Text>
-              <Text>
-                { project.location.name }
-              </Text>
-            </Box>
-          </Grid>
+        <Box sx={{ pb: [2, 2, '18px'] }}>
+        <Divider sx={{ mr: [0, 0, 2], mt: [0], mb: [0] }}/>
+        {metrics.map((metric) => 
+          <Metric 
+            key={metric.name} 
+            tag={project.tags[0]}
+            metric={metric}
+          ></Metric>) }
+        <Grid columns={[1, 1, '300px 1fr']}>
+          <Box sx={{ fontSize: [1], mt: ['8px', '8px', 2] }}>
+            <Text sx={{ color: 'secondary' }}>Source</Text>
+            <Text>
+              <Link sx={{ 
+                textDecoration: 'none',
+                '&:hover': {
+                  color: 'secondary'
+                },
+                '&:hover > #arrow': {
+                  color: 'secondary'
+                }
+              }} href={ project.source.url }>
+                { project.source.name }
+                <Text id='arrow' variant='arrow'>↗</Text>
+              </Link>
+            </Text>
           </Box>
-        }
+          <Box sx={{ fontSize: [1], pr: [2], mt: [0, 0, 2], mb: [2, 2, 0], textAlign: ['left', 'left', 'right'] }}>
+            <Text sx={{ color: 'secondary' }}>Location</Text>
+            <Text>
+              { project.location.name }
+            </Text>
+          </Box>
+        </Grid>
+        </Box>
+      }
       </Box>
+      
     </Box>
   } else {
     return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -3652,11 +3652,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
-    "fuse.js": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-5.2.3.tgz",
-      "integrity": "sha512-ld3AEgKtKnnXCtJavtygAb+aLlD5aVvLwTocXXBSStLA6JGFI6oMxTvumwh46N2/3gs3A7JNDu1px5F1/cq84g=="
-    },
     "gensync": {
       "version": "1.0.0-beta.1",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",


### PR DESCRIPTION
This adds some subtle animations to expanding reports and metrics, using a mix of opacity and height transitions. Pure CSS, no new libraries added. I made the animations slightly slower and more pronounced on mobile, where we otherwise have no cues as to position on the page, so it's easier to feel vertically lost.

I considered animations on close but it's more complicated to implement (as we're showing / hiding the elements), and I didn't like how it felt anyway (not snappy enough).

![animations](https://user-images.githubusercontent.com/3387500/82743714-1a121e80-9d24-11ea-8b07-b1f77930341d.gif)


