### PR TITLE
animate heights

### DIFF
--- a/components/metric.js
+++ b/components/metric.js
@@ -5,6 +5,7 @@ import Squares from './graphics/squares'
 import Emissions from './graphics/emissions'
 import Check from './icons/check'
 import Ex from './icons/ex'
+import AnimateHeight from 'react-animate-height'
 import { Box, Divider, jsx, Grid, Text, IconButton } from 'theme-ui'
 import { useState } from 'react'
 import { useThemeUI } from 'theme-ui'
@@ -20,6 +21,10 @@ const Metric = ({ metric, tag }) => {
   const toggle = (e) => {
     setExpanded(!expanded)
   }
+
+  const length = (metric.comment ? metric.comment.length : 0) +
+    (metric.notes ? metric.notes.length : 0)
+  const duration = Math.min(Math.max(length / 2, 100), 200) * 0.75
 
   const hasUnits = (metric.units != '')
   const hasDetails = ((metric.notes != '') || (metric.comment != ''))
@@ -97,14 +102,11 @@ const Metric = ({ metric, tag }) => {
         }
       </Box>
       </Box>
-      <Box sx={{
-        opacity: expanded ? 1 : 0,
-        maxHeight: expanded ? 'auto' : '0px',
-        overflow: 'hidden',
-        transition: [
-          'max-height 0.2s ease-in'
-        ]
-      }}>
+      <AnimateHeight
+        duration={duration}
+        height={expanded ? 'auto' : 0}
+        easing={'linear'}
+      >
       {expanded && 
         <Box sx={{ pb: [1] }}>
         <Box sx={{ 
@@ -146,7 +148,7 @@ const Metric = ({ metric, tag }) => {
         </Box>
         </Box>
       }
-      </Box>
+      </AnimateHeight>
       <Divider sx={{ mr: [0, 0, 2], mt: [0], mb: [0] }}/>
     </Box>
 
@@ -200,14 +202,11 @@ const Metric = ({ metric, tag }) => {
         }
       </Grid>
     </Box>
-    <Box sx={{
-      opacity: expanded ? 1 : 0,
-      maxHeight: expanded ? 'auto' : '0px',
-      overflow: 'hidden',
-      transition: [
-        'max-height 0.1s ease-in'
-      ]
-    }}>
+    <AnimateHeight
+      duration={duration}
+      height={expanded ? 'auto' : 0}
+      easing={'linear'}
+    >
     {expanded && 
       <Box sx={{ pb: [1] }}>
       <Box sx={{ 
@@ -257,7 +256,7 @@ const Metric = ({ metric, tag }) => {
       </Box>
       </Box>
     }
-    </Box>
+    </AnimateHeight>
     <Divider sx={{ mr: [2], mt: [0], mb: [0] }}/>
     </Box>
   </Box>

--- a/components/report.js
+++ b/components/report.js
@@ -1,6 +1,6 @@
 import Metric from './metric'
 import Expander from './expander'
-import Cycle from './graphics/cycle'
+import AnimateHeight from 'react-animate-height'
 import { Badge, Link, Grid, Box, Divider, Heading, Text, IconButton } from 'theme-ui'
 import { alpha } from '@theme-ui/color'
 import { useSelector, useDispatch } from 'react-redux'
@@ -90,16 +90,14 @@ const Report = ({ project }) => {
       </Box>
       </Grid>
       </Box>
+      <AnimateHeight
+        duration={200}
+        height={ (expanded || showOne) ? 'auto' : 0 }
+        easing={'linear'}
+      >
       <Box sx={{
         pr: [0, 0, 4],
-        opacity: (expanded || showOne) ? 1 : 0,
-        maxHeight: (expanded || showOne) ? 'auto' : '0px',
-        overflow: 'hidden',
-        transition: [
-          'opacity 0.15s ease-in, max-height 0.25s ease-in',
-          'opacity 0.15s ease-in, max-height 0.25s ease-in',
-          'max-height 0.15s ease-in'
-        ]
+        opacity: (expanded || showOne) ? 1 : 0
       }}>
         {(expanded || showOne) && 
         <Box sx={{ pb: [2, 2, '18px'] }}>
@@ -138,7 +136,7 @@ const Report = ({ project }) => {
         </Box>
       }
       </Box>
-      
+      </AnimateHeight>
     </Box>
   } else {
     return null

--- a/package-lock.json
+++ b/package-lock.json
@@ -2609,6 +2609,11 @@
         }
       }
     },
+    "classnames": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+    },
     "cliui": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5363,6 +5368,15 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-animate-height": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.21.tgz",
+      "integrity": "sha512-CZHdjMD8qqp10tYtWmauWYASXxxv9vYeljxFGFtbcrbNXhsUv0w3IjxVK+0yCnyfk7769WfMZKHra4vRcbMnQg==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.1"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "next": "^9.3.4",
     "react": "^16.13.1",
+    "react-animate-height": "^2.0.21",
     "react-dom": "^16.13.1",
     "react-redux": "^7.2.0",
     "react-vega": "^7.3.0",


### PR DESCRIPTION
Alternative implementation of height animation for opening reports and metrics. Uses the [`react-animate-height`](https://github.com/Stanko/react-animate-height) package, which properly handles a `height` of `auto`, but is otherwise using CSS transitions. 

The report heights can vary significantly (depending on which metrics are expanded), and the height of the metrics themselves vary based on the length of the comments. Much cleaner to use `auto` then to pick a fixed `max-height`, and this package makes it easy!